### PR TITLE
feat: sqlx support

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,2 @@
 [alias]
-test-all = "test --features sea-orm,serde"
+test-all = "test --features sea-orm,serde,sqlx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,16 @@ documentation = "https://docs.rs/serde-email/latest/serde-email"
 default = ["serde"]
 serde = ["dep:serde"]
 sea-orm = ["dep:sea-orm"]
+sqlx = ["dep:sqlx"]
 
 [dependencies]
 email_address = "0.2.4"
 sea-orm = { version = "0.10.7", optional = true }
 serde = { version = "1.0.152", optional = true }
+sqlx = { version = "0.6.3", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.91"
 sea-orm = "0.10.7"
 serde = "1.0.152"
+sqlx = { version = "0.6.3", features = ["runtime-tokio-rustls"] }

--- a/src/email.rs
+++ b/src/email.rs
@@ -23,6 +23,11 @@ mod sea_orm_support;
 #[cfg(feature = "sea-orm")]
 pub use self::sea_orm_support::*;
 
+#[cfg(feature = "sqlx")]
+mod sqlx_support;
+#[cfg(feature = "sqlx")]
+pub use self::sqlx_support::*;
+
 /// This is a wrapper around a String. Which can only be created,
 /// by validating the string is an email.
 ///

--- a/src/email/sqlx_support.rs
+++ b/src/email/sqlx_support.rs
@@ -1,0 +1,37 @@
+use ::sqlx::database::HasArguments;
+use ::sqlx::database::HasValueRef;
+use ::sqlx::decode::Decode;
+use ::sqlx::encode::Encode;
+use ::sqlx::encode::IsNull;
+use ::sqlx::Database;
+
+use crate::Email;
+
+impl<'q, DB: Database> Encode<'q, DB> for Email
+where
+    String: Encode<'q, DB>,
+{
+    fn encode_by_ref(&self, buf: &mut <DB as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+        <String as Encode<'q, DB>>::encode_by_ref(self.as_string(), buf)
+    }
+    fn produces(&self) -> Option<DB::TypeInfo> {
+        <String as Encode<'q, DB>>::produces(self.as_string())
+    }
+    fn size_hint(&self) -> usize {
+        <String as Encode<'q, DB>>::size_hint(self.as_string())
+    }
+}
+
+impl<'r, DB: Database> Decode<'r, DB> for Email
+where
+    String: Decode<'r, DB>,
+{
+    fn decode(
+        value: <DB as HasValueRef<'r>>::ValueRef,
+    ) -> Result<Self, Box<dyn ::std::error::Error + 'static + Send + Sync>> {
+        let string = <String as Decode<'r, DB>>::decode(value)?;
+        let result = Email::new(string)?;
+
+        Ok(result)
+    }
+}


### PR DESCRIPTION
The methodology used for implementing this was to use rust analyzer's macro expansion feature on `#[derive(Type)] struct Email(String);` and then modify it to work on `crate::Email`.